### PR TITLE
Update block.json schema to support namespaces

### DIFF
--- a/json/block.json
+++ b/json/block.json
@@ -24,7 +24,7 @@
 		},
 		"name": {
 			"type": "string",
-			"pattern": "^[a-z][a-z0-9-]*$",
+			"pattern": "^[a-z][a-z0-9-/]*$",
 			"description": "The name for a block is a unique string that identifies a block. ACF will automatically add an `acf/` namespace if not provided."
 		},
 		"__experimental": {


### PR DESCRIPTION
Before this change, namespaces like `my-plugin/my-block` would throw an error.

Adding support for `/` allows these types of names to pass the schema validation.

Fixes #1 